### PR TITLE
fix: Ensure GOOGLE_CLOUD_PROJECT is properly set in Cloud Run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,7 @@ jobs:
         
         echo "🚀 Deploying to Cloud Run: $FULL_SERVICE_NAME"
         echo "   Environment: ${{ env.ENVIRONMENT }}"
+        echo "   Project ID: $PROJECT_ID"
         echo "   Min instances: $MIN_INSTANCES"
         echo "   Max instances: $MAX_INSTANCES"
         
@@ -118,6 +119,7 @@ jobs:
           --min-instances=$MIN_INSTANCES \
           --port=8080 \
           --set-env-vars="CONFLUENCE_SPACE_KEY=DEV,LOG_LEVEL=$LOG_LEVEL,GOOGLE_CLOUD_PROJECT=$PROJECT_ID,ENVIRONMENT=${{ env.ENVIRONMENT }}" \
+          --update-env-vars="GOOGLE_CLOUD_PROJECT=$PROJECT_ID" \
           --update-secrets="SLACK_BOT_TOKEN=SLACK_BOT_TOKEN:latest,SLACK_APP_TOKEN=SLACK_APP_TOKEN:latest,ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,GITHUB_ACCESS_TOKEN=GITHUB_ACCESS_TOKEN:latest,CONFLUENCE_URL=CONFLUENCE_URL:latest,CONFLUENCE_USERNAME=CONFLUENCE_USERNAME:latest,CONFLUENCE_API_TOKEN=CONFLUENCE_API_TOKEN:latest"
     
     - name: Get service URL


### PR DESCRIPTION
- Add PROJECT_ID to deployment logs for debugging
- Add explicit --update-env-vars for GOOGLE_CLOUD_PROJECT
- Ensures Secret Manager can access project-specific secrets
- Fixes environment variable retrieval issues

🤖 Generated with [Claude Code](https://claude.ai/code)