### PR TITLE
fix: Use valid Cloud Build machine type

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
         echo "🐳 Building Docker image: $IMAGE_TAG"
         
         # Cloud Build with better error handling and timeout
-        gcloud builds submit --tag=$IMAGE_TAG . --timeout=1200s --machine-type=e2-standard-4 || {
+        gcloud builds submit --tag=$IMAGE_TAG . --timeout=1200s --machine-type=e2-highcpu-8 || {
           echo "❌ Cloud Build failed. Checking build status..."
           gcloud builds list --limit=1 --filter="status=FAILURE OR status=TIMEOUT"
           exit 1


### PR DESCRIPTION
- Change from e2-standard-4 to e2-highcpu-8 for Cloud Build
- e2-standard-4 is not available in Cloud Build machine types
- e2-highcpu-8 provides better performance for build workloads

🤖 Generated with [Claude Code](https://claude.ai/code)