### PR TITLE
fix: Implement minimal Flask server for Cloud Run startup debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,20 @@ RUN apt-get update && apt-get install -y \
 # Copy requirements first for better caching
 COPY requirements.txt .
 
-# Install Python dependencies with verbose output for debugging
+# Install Python dependencies step by step for debugging
+RUN pip install --no-cache-dir flask>=2.0.0 requests>=2.25.0 gunicorn>=20.1.0
 RUN pip install --no-cache-dir --verbose -r requirements.txt
 
-# Copy application code
-COPY . .
+# Copy application code (essential files first)
+COPY main.py .
+COPY aibot.py .
+COPY atlassian_mcp_integration.py .
 
 # Expose port
 EXPOSE 8080
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+# Health check with extended timing
+HEALTHCHECK --interval=60s --timeout=30s --start-period=120s --retries=5 \
     CMD curl -f http://localhost:8080/health || exit 1
 
 # Run the application

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,34 @@
+# Use Python 3.11 runtime (stable and widely supported)
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PORT=8080
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies (minimal)
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy minimal requirements
+COPY requirements-minimal.txt .
+
+# Install Python dependencies (minimal set)
+RUN pip install --no-cache-dir -r requirements-minimal.txt
+
+# Copy main application file only
+COPY main.py .
+
+# Expose port
+EXPOSE 8080
+
+# Health check with extended start period
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+# Run the application
+CMD ["python", "main.py"]

--- a/main-minimal.py
+++ b/main-minimal.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+最小限のCloud Run用ヘルスサーバー
+確実にport 8080でリッスンするテスト用実装
+"""
+
+import os
+import logging
+from flask import Flask, jsonify
+
+# ロギング設定
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+logger = logging.getLogger(__name__)
+
+# Flaskアプリ作成
+app = Flask(__name__)
+
+@app.route("/", methods=["GET"])
+def root():
+    return jsonify({
+        "status": "running",
+        "service": "slack-ai-bot-minimal",
+        "port": os.environ.get("PORT", "8080")
+    }), 200
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({
+        "status": "healthy",
+        "service": "slack-ai-bot-minimal"
+    }), 200
+
+@app.route("/test", methods=["GET"])
+def test():
+    return jsonify({
+        "message": "Cloud Run deployment test successful",
+        "env_vars": {
+            "PORT": os.environ.get("PORT"),
+            "GOOGLE_CLOUD_PROJECT": os.environ.get("GOOGLE_CLOUD_PROJECT"),
+            "LOG_LEVEL": os.environ.get("LOG_LEVEL")
+        }
+    }), 200
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    logger.info(f"🚀 最小限ヘルスサーバー起動中 - Port: {port}")
+    
+    try:
+        app.run(
+            host="0.0.0.0",
+            port=port,
+            debug=False,
+            threaded=True
+        )
+    except Exception as e:
+        logger.error(f"❌ サーバー起動失敗: {e}")
+        exit(1)

--- a/main.py
+++ b/main.py
@@ -1,113 +1,70 @@
 #!/usr/bin/env python3
 """
-Google Cloud Run エントリーポイント (Socket Mode + Health Check Server)
-確実にport 8080でリッスンする簡潔な実装
+Google Cloud Run エントリーポイント
+段階的にSlack機能を追加する戦略
 """
 
 import os
 import logging
-import sys
-import threading
-import time
 from flask import Flask, jsonify
 
 # ロギング設定
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(levelname)s - %(message)s'
 )
 
 logger = logging.getLogger(__name__)
 
-def create_health_app():
-    """ヘルスチェック用のFlaskアプリを作成"""
-    app = Flask(__name__)
-    
-    @app.route("/health", methods=["GET"])
-    def health_check():
-        return jsonify({"status": "healthy", "service": "slack-ai-bot"}), 200
+# Flaskアプリ作成
+app = Flask(__name__)
 
-    @app.route("/", methods=["GET"])
-    def root():
-        return jsonify({"status": "running", "service": "slack-ai-bot"}), 200
-    
-    return app
+@app.route("/", methods=["GET"])
+def root():
+    return jsonify({
+        "status": "running",
+        "service": "slack-ai-bot",
+        "version": "2.0"
+    }), 200
 
-def initialize_socket_mode():
-    """Socket Modeを安全に初期化（別スレッド）"""
-    def socket_mode_worker():
-        time.sleep(10)  # ヘルスサーバーの完全起動を待つ
-        
-        try:
-            logger.info("🔌 Socket Mode初期化を開始...")
-            
-            # 環境変数の基本チェック
-            if os.environ.get("GITHUB_ACTIONS"):
-                logger.info("GitHub Actions環境でのビルド - Socket Modeスキップ")
-                return
-            
-            # aibot.pyのimportを試行
-            try:
-                logger.info("📦 aibot.pyをimport中...")
-                from aibot import app as slack_app, SLACK_APP_TOKEN
-                logger.info("✅ aibot.py import成功")
-                
-                if not SLACK_APP_TOKEN:
-                    logger.warning("⚠️ SLACK_APP_TOKEN未設定 - Socket Modeスキップ")
-                    return
-                
-                logger.info(f"🔑 SLACK_APP_TOKEN: {SLACK_APP_TOKEN[:10]}...")
-                
-                # Socket Mode Handler起動
-                from slack_bolt.adapter.socket_mode import SocketModeHandler
-                handler = SocketModeHandler(slack_app, SLACK_APP_TOKEN)
-                
-                logger.info("🚀 Socket Mode接続開始...")
-                handler.start()  # ブロッキング実行
-                
-            except ImportError as e:
-                logger.error(f"❌ aibot.py import失敗: {e}")
-                logger.info("ヘルスチェックサーバーのみで継続")
-            except Exception as e:
-                logger.error(f"❌ Socket Mode初期化エラー: {e}")
-                logger.info("ヘルスチェックサーバーのみで継続")
-                
-        except Exception as e:
-            logger.error(f"❌ Socket Mode worker予期せぬエラー: {e}")
-    
-    # Socket Modeを別スレッドで実行（失敗してもヘルスサーバーに影響しない）
-    socket_thread = threading.Thread(target=socket_mode_worker, daemon=True)
-    socket_thread.start()
-    logger.info("🔌 Socket Mode初期化スレッド開始")
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({
+        "status": "healthy",
+        "service": "slack-ai-bot"
+    }), 200
 
-def main():
-    """メイン関数 - 確実にヘルスサーバーを起動"""
-    logger.info("🤖 Slack AI Bot (Cloud Run) 起動開始...")
+@app.route("/debug", methods=["GET"])
+def debug():
+    """デバッグ情報エンドポイント"""
+    env_info = {
+        "PORT": os.environ.get("PORT"),
+        "GOOGLE_CLOUD_PROJECT": os.environ.get("GOOGLE_CLOUD_PROJECT"),
+        "ENVIRONMENT": os.environ.get("ENVIRONMENT"),
+        "LOG_LEVEL": os.environ.get("LOG_LEVEL"),
+        "PYTHONUNBUFFERED": os.environ.get("PYTHONUNBUFFERED")
+    }
     
-    # ポート設定
+    return jsonify({
+        "message": "Debug information",
+        "environment": env_info,
+        "slack_ready": False  # 今回はシンプル版
+    }), 200
+
+if __name__ == "__main__":
     port = int(os.environ.get("PORT", 8080))
-    logger.info(f"🌐 ポート設定: {port}")
+    logger.info(f"🚀 シンプル版 Slack AI Bot 起動中 - Port: {port}")
     
-    # Flaskアプリ作成
-    health_app = create_health_app()
-    logger.info("✅ ヘルスチェックアプリ作成完了")
-    
-    # Socket Mode初期化（非ブロッキング）
-    initialize_socket_mode()
-    
-    # メインスレッドでヘルスサーバー実行（最優先）
     try:
-        logger.info(f"🚀 ヘルスチェックサーバー起動中 (port:{port})...")
-        health_app.run(
+        app.run(
             host="0.0.0.0",
             port=port,
             debug=False,
-            use_reloader=False,
             threaded=True
         )
+        logger.info("✅ サーバー起動成功")
     except Exception as e:
-        logger.error(f"❌ ヘルスサーバー起動失敗: {e}")
-        sys.exit(1)
-
-if __name__ == "__main__":
-    main()
+        logger.error(f"❌ サーバー起動失敗: {e}")
+        import traceback
+        logger.error(f"トレースバック: {traceback.format_exc()}")
+        exit(1)

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,0 +1,3 @@
+flask>=2.0.0
+requests>=2.25.0
+gunicorn>=20.1.0


### PR DESCRIPTION
- Simplify main.py to basic Flask app (no Slack dependencies)
- Add main-minimal.py for absolute minimal testing
- Create requirements-minimal.txt and Dockerfile.minimal for isolation testing
- Step-by-step dependency installation in Dockerfile for debugging
- Extended health check timing (120s start-period, 5 retries)
- Focus on reliable port 8080 binding before adding Slack features

🤖 Generated with [Claude Code](https://claude.ai/code)