### PR TITLE
fix: Add Gunicorn-based production deployment approach

### DIFF
--- a/.github/workflows/deploy-simple.yml
+++ b/.github/workflows/deploy-simple.yml
@@ -1,0 +1,89 @@
+name: Deploy Simple Version to Cloud Run
+
+# Workload Identity Federation用の権限設定
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+        - staging
+        - production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    
+    env:
+      SERVICE_NAME: slack-ai-bot-simple
+      REGION: asia-northeast1
+      ENVIRONMENT: ${{ github.event.inputs.environment || 'staging' }}
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+    
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+    
+    - name: Get Project ID from gcloud
+      id: project
+      run: |
+        PROJECT_ID=$(gcloud config get-value project)
+        echo "PROJECT_ID=$PROJECT_ID" >> $GITHUB_OUTPUT
+        echo "Detected Project ID: $PROJECT_ID"
+    
+    - name: Configure Docker
+      run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev
+    
+    - name: Build and Deploy Simple Version
+      env:
+        PROJECT_ID: ${{ steps.project.outputs.PROJECT_ID }}
+      run: |
+        IMAGE_TAG=asia-northeast1-docker.pkg.dev/${PROJECT_ID}/slack-ai-bot/${SERVICE_NAME}:${{ github.sha }}
+        
+        echo "🐳 Building simple Docker image: $IMAGE_TAG"
+        gcloud builds submit --tag=$IMAGE_TAG -f Dockerfile.simple .
+        
+        echo "🚀 Deploying simple version to Cloud Run"
+        gcloud run deploy $SERVICE_NAME \
+          --image=$IMAGE_TAG \
+          --region=$REGION \
+          --platform=managed \
+          --allow-unauthenticated \
+          --timeout=300s \
+          --memory=512Mi \
+          --cpu=1000m \
+          --max-instances=3 \
+          --min-instances=0 \
+          --port=8080 \
+          --set-env-vars="ENVIRONMENT=$ENVIRONMENT,GOOGLE_CLOUD_PROJECT=$PROJECT_ID,PORT=8080"
+    
+    - name: Get service URL and test
+      env:
+        PROJECT_ID: ${{ steps.project.outputs.PROJECT_ID }}
+      run: |
+        SERVICE_URL=$(gcloud run services describe $SERVICE_NAME --region=$REGION --format="value(status.url)")
+        echo "🌐 Service URL: $SERVICE_URL"
+        
+        echo "🏥 Testing health endpoint..."
+        sleep 30
+        curl -f "$SERVICE_URL/health" || echo "Health check failed"
+        
+        echo "🧪 Testing debug endpoint..."
+        curl -f "$SERVICE_URL/debug" || echo "Debug endpoint failed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=60s --timeout=30s --start-period=120s --retries=5 \
     CMD curl -f http://localhost:8080/health || exit 1
 
-# Run the application
-CMD ["python", "main.py"]
+# Run the application with Gunicorn for production
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -1,0 +1,21 @@
+# 最もシンプルなDockerfile
+FROM python:3.11-slim
+
+# 作業ディレクトリ
+WORKDIR /app
+
+# 環境変数
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8080
+
+# 最小限の依存関係をインストール
+RUN pip install flask gunicorn
+
+# アプリファイルをコピー
+COPY app.py .
+
+# ポート公開
+EXPOSE 8080
+
+# Gunicornでアプリを起動
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 app:app

--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Cloud Run用の最も基本的なFlaskアプリ
+Gunicorn WSGIサーバーで実行
+"""
+
+import os
+import logging
+from flask import Flask, jsonify
+
+# ロギング設定
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Flaskアプリ作成
+app = Flask(__name__)
+
+@app.route("/")
+def index():
+    return jsonify({
+        "message": "Hello from Cloud Run!",
+        "service": "slack-ai-bot",
+        "status": "running"
+    })
+
+@app.route("/health")
+def health():
+    return jsonify({
+        "status": "healthy",
+        "service": "slack-ai-bot"
+    })
+
+@app.route("/debug")
+def debug():
+    return jsonify({
+        "port": os.environ.get("PORT", "8080"),
+        "project": os.environ.get("GOOGLE_CLOUD_PROJECT", "not-set"),
+        "environment": os.environ.get("ENVIRONMENT", "not-set")
+    })
+
+if __name__ == "__main__":
+    # 開発用サーバー（本番ではGunicornを使用）
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/main.py
+++ b/main.py
@@ -16,8 +16,11 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-# Flaskアプリ作成
+# Flaskアプリ作成（Gunicorn用）
 app = Flask(__name__)
+
+# Gunicorn用のappオブジェクト
+application = app
 
 @app.route("/", methods=["GET"])
 def root():


### PR DESCRIPTION
- Create app.py: Ultra-simple Flask app for testing
- Add Dockerfile.simple: Minimal Docker configuration
- Add deploy-simple.yml: Dedicated simple deployment workflow
- Update main.py and Dockerfile to use Gunicorn WSGI server
- Use production-grade Gunicorn instead of Flask dev server
- Reduce timeout to 300s and memory to 512Mi for faster startup

🤖 Generated with [Claude Code](https://claude.ai/code)